### PR TITLE
Refactor targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 
 _targets/*
+*/out/*

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,22 +1,18 @@
 
-download_nwis_data <- function(site_nums = c("01427207", "01432160", "01435000", "01436690", "01466500")){
+download_nwis_data <- function(site_num){
   
   # create the file names that are needed for download_nwis_site_data
   # tempdir() creates a temporary directory that is wiped out when you start a new R session; 
   # replace tempdir() with "1_fetch/out" or another desired folder if you want to retain the download
-  download_files <- file.path(tempdir(), paste0('nwis_', site_nums, '_data.csv'))
-  data_out <- data.frame()
-  # loop through files to download 
-  for (download_file in download_files){
-    download_nwis_site_data(download_file, parameterCd = '00010')
-    # read the downloaded data and append it to the existing data.frame
-    these_data <- read_csv(download_file, col_types = 'ccTdcc')
-    data_out <- bind_rows(data_out, these_data)
-  }
+  download_file <- file.path(tempdir(), paste0('nwis_', site_num, '_data.csv'))
+  download_nwis_site_data(download_file, parameterCd = '00010')
+  data_out <- read_csv(download_file, col_types = 'ccTdcc')
   return(data_out)
+
 }
 
-nwis_site_info <- function(fileout, site_data){
+nwis_site_info <- function(fileout, ...){
+  site_data <- bind_rows(...)
   site_no <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_no)
   write_csv(site_info, fileout)

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,31 +1,11 @@
-
-download_nwis_data <- function(site_num){
-  
-  # create the file names that are needed for download_nwis_site_data
-  # tempdir() creates a temporary directory that is wiped out when you start a new R session; 
-  # replace tempdir() with "1_fetch/out" or another desired folder if you want to retain the download
-  download_file <- file.path(tempdir(), paste0('nwis_', site_num, '_data.csv'))
-  download_nwis_site_data(download_file, parameterCd = '00010')
-  data_out <- read_csv(download_file, col_types = 'ccTdcc')
-  return(data_out)
-
-}
-
-nwis_site_info <- function(fileout, ...){
+nwis_site_info <- function(fileout, site_data){
   site_no <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_no)
   write_csv(site_info, fileout)
   return(fileout)
 }
 
-
-download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01"){
-  
-  # filepaths look something like directory/nwis_01432160_data.csv,
-  # remove the directory with basename() and extract the 01432160 with the regular expression match
-  site_num <- basename(filepath) %>% 
-    stringr::str_extract(pattern = "(?:[0-9]+)")
-  
+download_nwis_site_data <- function(site_num, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01"){
   # readNWISdata is from the dataRetrieval package
   data_out <- readNWISdata(sites=site_num, service="iv", 
                            parameterCd = parameterCd, startDate = startDate, endDate = endDate)
@@ -37,7 +17,7 @@ download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="
   }
   # -- end of do-not-edit block
   
-  write_csv(data_out, file = filepath)
-  return(filepath)
+  return(data_out)
+
 }
 

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -12,7 +12,6 @@ download_nwis_data <- function(site_num){
 }
 
 nwis_site_info <- function(fileout, ...){
-  site_data <- bind_rows(...)
   site_no <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_no)
   write_csv(site_info, fileout)

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -1,19 +1,9 @@
-process_data <- function(nwis_data){
+process_data <- function(nwis_data, site_info_csv){
   nwis_data_clean <- rename(nwis_data, water_temperature = X_00010_00000) %>% 
-    select(-agency_cd, -X_00010_00000_cd, -tz_cd)
+    left_join(read_csv(site_info_csv), by = "site_no") %>% 
+    select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va) %>%
+    mutate(station_name = as.factor(station_name))
   
   return(nwis_data_clean)
 }
 
-annotate_data <- function(site_data_clean, site_filename){
-  site_info <- read_csv(site_filename)
-  annotated_data <- left_join(site_data_clean, site_info, by = "site_no") %>% 
-    select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va)
-  
-  return(annotated_data)
-}
-
-
-style_data <- function(site_data_annotated){
-  mutate(site_data_annotated, station_name = as.factor(station_name))
-}

--- a/_targets.R
+++ b/_targets.R
@@ -8,12 +8,32 @@ tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse b
 
 p1_targets_list <- list(
   tar_target(
+    site_01427207,
+    download_nwis_data(site_num = "01427207"),
+  ),
+  tar_target(
+    site_01432160,
+    download_nwis_data(site_num = "01432160"),
+  ),
+  tar_target(
+    site_01435000,
+    download_nwis_data(site_num = "01435000"),
+  ),
+  tar_target(
+    site_01436690,
+    download_nwis_data(site_num = "01436690"),
+  ),
+  tar_target(
+    site_01466500,
+    download_nwis_data(site_num = "01466500"),
+  ),
+  tar_target(
     site_data,
-    download_nwis_data(),
+    bind_rows(site_01427207, site_01432160, site_01435000, site_01436690, site_01466500),
   ),
   tar_target(
     site_info_csv,
-    nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data),
+    nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_01427207, site_01432160, site_01435000, site_01436690, site_01466500),
     format = "file"
   )
 )

--- a/_targets.R
+++ b/_targets.R
@@ -41,22 +41,14 @@ p1_targets_list <- list(
 p2_targets_list <- list(
   tar_target(
     site_data_clean, 
-    process_data(site_data)
-  ),
-  tar_target(
-    site_data_annotated,
-    annotate_data(site_data_clean, site_filename = site_info_csv)
-  ),
-  tar_target(
-    site_data_styled,
-    style_data(site_data_annotated)
+    process_data(site_data, site_info_csv)
   )
 )
 
 p3_targets_list <- list(
   tar_target(
     figure_1_png,
-    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_styled),
+    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_clean),
     format = "file"
   )
 )


### PR DESCRIPTION
Breaks up `site_data` target by removing for loop and executing as site-level targets that are then combined into `site_data`. This also simplifies the target trail to create a clean & plot-ready target. This was done by combining separate functions in `process_and_style.R` into a single function that does everything and takes `site_info_csv` as an additional parameter. 